### PR TITLE
it.source causes exception in some/all cases

### DIFF
--- a/src/groovy/com/grailsrocks/functionaltest/FunctionalTestException.groovy
+++ b/src/groovy/com/grailsrocks/functionaltest/FunctionalTestException.groovy
@@ -36,7 +36,7 @@ class FunctionalTestException extends junit.framework.AssertionFailedError {
         pw.println "URL Stack that resulted in ${hackedCause ?: 'failure'}"
         pw.println "---------------"
         urlStack?.reverseEach {
-            pw.println "${it.url} (${it.source})"
+            pw.println "${it.url} ${!it.hasProperty('source') ?: "$it.source"}"
         }
         pw.println "---------------"
         


### PR DESCRIPTION
fixed exception that was thrown when running tests.
