### PR TITLE
Renamed addAdditionalHeader to setAdditionalHeader to fix GPFUNCTIONAL-114

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -52,6 +52,10 @@ grails.project.dependency.resolution = {
         test( 'xalan:xalan:2.7.1') {
             excludes 'xml-apis', 'xerces'
         }
+        
+        test('org.apache.httpcomponents:httpmime:4.1.3') {
+            excludes 'xml-apis', 'xerces'
+        }
 /*
         test( 'xercesImpl:xercesImpl:2.9.1') {
             excludes 'xml-apis'

--- a/src/groovy/com/grailsrocks/functionaltest/client/BrowserClient.groovy
+++ b/src/groovy/com/grailsrocks/functionaltest/client/BrowserClient.groovy
@@ -226,7 +226,7 @@ class BrowserClient implements Client, WebWindowListener, HtmlAttributeChangeLis
         if (currentAuthInfo) {
             // @todo We could use htmlunit auth stuff here?
             def encoded = Base64Codec.encode("${currentAuthInfo.user}:${currentAuthInfo.credentials}".getBytes('utf-8'))
-            settings.addAdditionalHeader('Authorization', "Basic "+encoded)
+            settings.setAdditionalHeader('Authorization', "Basic "+encoded)
         }
 
         def wrapper
@@ -241,7 +241,7 @@ class BrowserClient implements Client, WebWindowListener, HtmlAttributeChangeLis
         }
         headerLists.each { headers ->
             for (entry in headers) { 
-                settings.addAdditionalHeader(entry.key, entry.value.toString())
+                settings.setAdditionalHeader(entry.key, entry.value.toString())
             }
         }
 


### PR DESCRIPTION
Setting headers for GET and POST requests is currently broken with 2.0M2 due to the API change in HTMLUnit noted here:

http://jira.grails.org/browse/GPFUNCTIONALTEST-114

This pull request fixes the issue by renaming the method names in BrowserClient to those now used by HTMLUnit.
