### PR TITLE
Fix getJSON() return type 

### DIFF
--- a/src/groovy/com/grailsrocks/functionaltest/TestCaseBase.groovy
+++ b/src/groovy/com/grailsrocks/functionaltest/TestCaseBase.groovy
@@ -36,6 +36,7 @@ import com.grailsrocks.functionaltest.util.TestUtils
 import junit.framework.AssertionFailedError
 
 import com.grailsrocks.functionaltest.client.*
+import org.codehaus.groovy.grails.web.json.JSONElement
 
 class TestCaseBase extends GroovyTestCase implements GroovyInterceptable, ClientAdapter {
 
@@ -413,8 +414,8 @@ class TestCaseBase extends GroovyTestCase implements GroovyInterceptable, Client
         
         return response.contentAsString.decodeJSON()
     }
-*/    
-    GPathResult getJSON() {
+*/
+    JSONElement getJSON() {
         assertContentType contentTypeForJSON
         grails.converters.JSON.parse(client.responseAsString)
     }


### PR DESCRIPTION
The getJSON() return type is incorrect (probably a copy/paste error from getXML).
