### PR TITLE
Preserve response data on error. RESTClient still has response data for HTTP >= 400 status

### DIFF
--- a/src/groovy/com/grailsrocks/functionaltest/client/APIClient.groovy
+++ b/src/groovy/com/grailsrocks/functionaltest/client/APIClient.groovy
@@ -173,6 +173,32 @@ class APIClient implements Client {
                     statusCode: responseStatus)
         } catch (HttpResponseException e) {
             response = e.response
+
+            if (response.data != null) {
+
+                // @todo need to copy the response data first, then mutate it to string also
+                // as RESTClient only lets you read the response once.
+
+                switch (response.contentType) {
+                    case ~'application/json.*':
+                    case ~'text/.*':
+                        responseString = response.data.text
+                        break;
+                    default:
+                        println "yresp is: ${response.data.getClass()}"
+                        byte[] bytes = new byte[100]
+                        response.data.read(bytes)
+                        responseString = "Binary file:\r\n" + new String(bytes, 'utf-8')
+                        def n = response.data.available()
+                        if (n) {
+                            responseString += "\r\n and $n more bytes"
+                        }
+                        break;
+                }
+            } else {
+                responseString = ''
+            }
+
             event = new ContentChangedEvent(
                     client: this, 
                     url: this.url,


### PR DESCRIPTION
There's still data in HTTP responses >= 400. RESTClient will preserve that data and then throw the exception. I know this is duplicate code for the try, so ripe for refactoring. I tried playing around with failure handlers. I want to do what RESTClient.defaultFailureHandler() without throwing the exception, but it relies on HTTPBuilder.defaultSuccessHandler() which is protected and non-trivial. The only clean way I can think of would be to subclass RESTClient and override defaultFailureHandler, then having access to HTTPBuilder.defaultSuccessHandler(). I know you have the TODO in there to change/remove the failure handler. If you want to go down that route. I could make the changes and submit a pull request.
