### PR TITLE
MissingPropertyException calling TestCaseBase.assertRedirectUrl

### DIFF
--- a/src/groovy/com/grailsrocks/functionaltest/TestCaseBase.groovy
+++ b/src/groovy/com/grailsrocks/functionaltest/TestCaseBase.groovy
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2008-2009 the original author or authors.
  *
@@ -337,7 +336,7 @@ class TestCaseBase extends GroovyTestCase implements GroovyInterceptable, Client
 	    if (redirectEnabled) {
 	        throw new IllegalStateException("Asserting redirect, but you have not disabled redirects. Do redirectEnabled = false first, then call followRedirect() after asserting.")
 	    }
-	    if (!HTTPUtils.isRedirectStatus(client.responseStatusCode)) {
+	    if (!HTTPUtils.isRedirectStatus(client.responseStatus)) {
 	        throw new AssertionFailedError("Asserting redirect, but response was not a valid redirect status code")
 	    }
 	    assertEquals expected, redirectUrl


### PR DESCRIPTION
TestCaseBase.assertRedirectUrl does not work at all. Looking into the code the property BrowserClient.responseStatusCode does not exist as the error suggests. Instead there is a responseStatus property that is successfully used by the surrounding code. Seems like simple forgetfulness.

This patch renames responseStatusCode to responseStatus in TestCaseBase.assertRedirectUrl
